### PR TITLE
Fix manual typos (#2259)

### DIFF
--- a/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
+++ b/src/kvirc/kvs/KviKvsCoreCallbackCommands.cpp
@@ -207,7 +207,7 @@ namespace KviKvsCoreCallbackCommands
 					[cmd]echo[/cmd] "j"
 				}
 				[comment]# Kill the whole 'letters' namespace[/comment]
-				alias(autoaway::){}
+				alias(letters::){}
 			[/example]
 		@seealso:
 			[doc:kvs_aliasesandfunctions]Aliases and functions[/doc]

--- a/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
+++ b/src/kvirc/kvs/KviKvsCoreFunctions_sz.cpp
@@ -535,7 +535,7 @@ namespace KviKvsCoreFunctions
 			[br]
 			Copy the translation file obtained in the following way:[br]
 			[example]
-				cp myscript.pot myscript_XX.pot
+				cp myscript.pot myscript_XX.po
 			[/example][br]
 			Where the XX is your country/language code. For example, for Italian
 			it would be:[br]


### PR DESCRIPTION
* Update KviKvsCoreCallbackCommands.cpp

To kill the whole 'letters' namespace you must delete de 'letters' namespace

* Update KviKvsCoreFunctions_sz.cpp

another typo

[//]: # (If your pull request is a fix to an open issue please add fixes #9999 to the commit comments.)
[//]: # (If your proposal involves GUI improvements, add screenshots of before and after to help visualise the proposal on the fly.)
#### Changes proposed
-
-
-

[//]: # (If you have write privileges to repository, do label your pull request, else you could insert a mention prefixed with @GitHub-Username below.)

