### PR TITLE
Fix for a problem with channel links

### DIFF
--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -2003,6 +2003,22 @@ void KviChannelWindow::preprocessMessage(QString & szMessage)
 		{
 			if((*it) == szTmp)
 				*it = QString("\r!c\r%1\r").arg(*it);
+			else if((KviControlCodes::Bold == (*it)[0]) &&
+				((it->length() - szTmp.length()) > 1))
+			{
+				int i = 1, j = 0;
+				for ( ; i < it->length(); ++i)
+				{
+					if((*it)[i] == szTmp[j])
+						++j;
+					else if(KviControlCodes::Bold == (*it)[i])
+					{
+						++i;
+						break;
+					}
+				}
+				*it = QString("\r!c%1\r%2\r%3").arg(szTmp.left(j), it->left(i), it->mid(i));
+			}
 			else
 				*it = QString("\r!c%1\r%2\r").arg(szTmp, *it);
 		}


### PR DESCRIPTION
In the MindForge net when a user receives an invite to a channel, an bot of the net sends you a notice in this format :

> [04:58:36] *[Minerva]* You have been invited to **#***.

the name of de channel is send in bold, and the line is ended with a dot (.) this makes KVIrc interpret the dot as part of the channel name creating a wrong link.