### PR TITLE
Fix for a problem with channel links

### DIFF
--- a/src/kvirc/ui/KviChannelWindow.cpp
+++ b/src/kvirc/ui/KviChannelWindow.cpp
@@ -2003,6 +2003,22 @@ void KviChannelWindow::preprocessMessage(QString & szMessage)
 		{
 			if((*it) == szTmp)
 				*it = QString("\r!c\r%1\r").arg(*it);
+			else if((KviControlCodes::Bold == (*it)[0]) &&
+				((it->length() - szTmp.length()) > 1))
+			{
+				int i = 1, j = 0;
+				for( ; i < it->length(); ++i)
+				{
+					if((*it)[i] == szTmp[j])
+						++j;
+					else if(KviControlCodes::Bold == (*it)[i])
+					{
+						++i;
+						break;
+					}
+				}
+				*it = QString("\r!c%1\r%2\r%3").arg(szTmp.left(j),it->left(i),it->mid(i));
+			}
 			else
 				*it = QString("\r!c%1\r%2\r").arg(szTmp, *it);
 		}

--- a/src/kvirc/ui/KviWindow.cpp
+++ b/src/kvirc/ui/KviWindow.cpp
@@ -1328,9 +1328,7 @@ void KviWindow::preprocessMessage(QString & szMessage)
 {
 	// FIXME: slow
 
-	if(!m_pConsole)
-		return;
-	if(!m_pConsole->connection())
+	if(!m_pConsole || !m_pConsole->connection())
 		return;
 
 	static QString szNonStandardLinkPrefix = QString::fromAscii("\r![");
@@ -1345,14 +1343,31 @@ void KviWindow::preprocessMessage(QString & szMessage)
 	{
 		if(it->contains('\r'))
 			continue;
-		QString szTmp(*it);
-		szTmp = KviControlCodes::stripControlBytes(szTmp).trimmed();
+
+		QString szTmp = KviControlCodes::stripControlBytes(*it).trimmed();
 		if(szTmp.length() < 1)
 			continue;
+
 		if(m_pConsole->connection()->serverInfo()->supportedChannelTypes().contains(szTmp[0]))
 		{
 			if((*it) == szTmp)
 				*it = QString("\r!c\r%1\r").arg(*it);
+			else if((KviControlCodes::Bold == (*it)[0]) &&
+				((it->length() - szTmp.length()) > 1))
+			{
+				int i = 1, j = 0;
+				for( ; i < it->length(); ++i)
+				{
+					if((*it)[i] == szTmp[j])
+						++j;
+					else if(KviControlCodes::Bold == (*it)[i])
+					{
+						++i;
+						break;
+					}
+				}
+				*it = QString("\r!c%1\r%2\r%3").arg(szTmp.left(j),it->left(i),it->mid(i));
+			}
 			else
 				*it = QString("\r!c%1\r%2\r").arg(szTmp,*it);
 		}


### PR DESCRIPTION
In the MindForge net when a user receives an invite to a channel, an bot of the net sends you a notice in this format :

> [04:58:36] *[Minerva]* You have been invited to **#ChannelName**.

the name of de channel is send in bold, and the line is ended with a dot (.) this makes KVIrc interpret the dot as part of the channel name creating a wrong link.